### PR TITLE
MinAttribute is an ambigous reference

### DIFF
--- a/Assets/CurlNoise/PostProcessing/Editor/PropertyDrawers/MinDrawer.cs
+++ b/Assets/CurlNoise/PostProcessing/Editor/PropertyDrawers/MinDrawer.cs
@@ -3,12 +3,12 @@ using UnityEngine.PostProcessing;
 
 namespace UnityEditor.PostProcessing
 {
-    [CustomPropertyDrawer(typeof(MinAttribute))]
+    [CustomPropertyDrawer(typeof(UnityEngine.PostProcessing.MinAttribute))]
     sealed class MinDrawer : PropertyDrawer
     {
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            MinAttribute attribute = (MinAttribute)base.attribute;
+            UnityEngine.PostProcessing.MinAttribute attribute = (UnityEngine.PostProcessing.MinAttribute)base.attribute;
 
             if (property.propertyType == SerializedPropertyType.Integer)
             {


### PR DESCRIPTION
Without explicitly referencing MinAttribute to either UnityEngine.PostProcessing.MinAttribute or UnityEngine.MinAttribute, unity will flag a compile error when starting playmode.
```'MinAttribute' is an ambiguous reference between 'UnityEngine.PostProcessing.MinAttribute' and 'UnityEngine.MinAttribute'```